### PR TITLE
Add ternary to handle case where address is missing and it causes a bug

### DIFF
--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -132,12 +132,12 @@ export const renderFlag = code => {
 };
 
 export const shortenAddressToolTip = address => {
-  return (
+  return address ? (
     <div data-tip={address}>
       {`${address.substring(0, 5)}...`}
       <ReactTooltip type="info" />
     </div>
-  );
+  ) : null;
 };
 
 export const toolTip = (displayText, toolTipText) => {


### PR DESCRIPTION
- Fixes bug where catalog table wasn't rendering when an address wasn't found for `address_last_seen` value.