### PR TITLE
Fix for pdf viewing on mobile

### DIFF
--- a/src/app/components/CookieBanner.js
+++ b/src/app/components/CookieBanner.js
@@ -30,9 +30,18 @@ export default function CookieBanner({ isBannerOpen, setIsBannerOpen }) {
           text="No Thanks"
         ></Button>
       </div>
-      <NavLink className="app__nav-link" to="/policy">
+      <NavLink className="app__nav-link app__hide-on-mobile" to="/policy">
         <p className="cookie-banner__link">Read our privacy policy</p>
       </NavLink>
+      <a
+        className="cookie-banner__link app__hide-on-desktop"
+        target="_blank"
+        and
+        rel="noopener noreferrer"
+        href="https://trusat-assets.s3.amazonaws.com/trusat.org_privacy_policy.pdf"
+      >
+        Read our privacy policy
+      </a>
     </div>
   ) : null;
 }

--- a/src/app/components/Footer.js
+++ b/src/app/components/Footer.js
@@ -7,12 +7,36 @@ export default function Footer() {
     <div className="footer">
       <div className="footer__content">
         <div className="footer__text-links-wrapper">
-          <NavLink className="app__nav-link footer__text-link" to="/terms">
-            Terms
+          <NavLink
+            className="app__nav-link footer__text-link app__hide-on-mobile"
+            to="/terms"
+          >
+            terms
           </NavLink>
-          <NavLink className="app__nav-link" to="/privacy">
-            Privacy
+          <a
+            className="app__link footer__text-link app__hide-on-desktop"
+            target="_blank"
+            and
+            rel="noopener noreferrer"
+            href="https://trusat-assets.s3.amazonaws.com/trusat_terms_of_use.pdf"
+          >
+            terms
+          </a>
+          <NavLink
+            className="app__nav-link footer__text-link app__hide-on-mobile"
+            to="/privacy"
+          >
+            privacy
           </NavLink>
+          <a
+            className="app__link footer__text-link app__hide-on-desktop"
+            target="_blank"
+            and
+            rel="noopener noreferrer"
+            href="https://trusat-assets.s3.amazonaws.com/trusat.org_privacy_policy.pdf"
+          >
+            privacy
+          </a>
         </div>
         <SocialIcons />
       </div>


### PR DESCRIPTION
Handles links for:
- whitepaper
- privacy policy
- terms of use

Will bounce user to a new tab on mobile render, and will keep desktop viewers within the app.