### PR TITLE
Fix pagination bug for new catalog filters 

### DIFF
--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -5,7 +5,6 @@ import JoinButton from "./JoinButton";
 import { NavLink } from "react-router-dom";
 import TrusatLogoSmallWhite from "../../assets/TrusatLogoSmallWhite.svg";
 import IconUser from "../../assets/icon-user.svg";
-import IconQuestion from "../../assets/icon-question.svg";
 import ReactGA from "react-ga";
 
 function NavBar(props) {

--- a/src/app/components/TablePaginator.js
+++ b/src/app/components/TablePaginator.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 
 export default function TablePaginator({
   tableDataLength,
@@ -68,7 +68,12 @@ export default function TablePaginator({
           {/* Change out "next" text when at end of the data currently being viewed */}
           {range.end >= tableDataLength ? (
             dataStart === undefined ? null : (
-              <p className="table-paginator__button-text">{`Load Next 200 >>`}</p>
+              <Fragment>
+                {/* Give user option to load more data if current dataset is 200 in length */}
+                {tableDataLength === 200 ? (
+                  <p className="table-paginator__button-text">{`Load Next 200 >>`}</p>
+                ) : null}
+              </Fragment>
             )
           ) : (
             <p className="table-paginator__button-text">{`Next >`}</p>


### PR DESCRIPTION
- The option to load the next 200 objects for a given `filter` is now only available when 200 objects have been pulled down from the backend and are currently displayed in the UI. 
- So for filters like `starlink` that as of writing only pull down 60 objects - the user will no longer be able to ask for more - because 60 is all that is currently in the dataset.
- closes #274 
- Cheers to @Kmoneal for the spot.