### PR TITLE
Adds option to download TLEs for all category filters

### DIFF
--- a/src/catalog/components/DownloadCatalogFilterTleButton.js
+++ b/src/catalog/components/DownloadCatalogFilterTleButton.js
@@ -66,7 +66,7 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
           <p>Something went wrong... {this.state.errorMessage}</p>
         ) : null}
 
-        <a className="app__hide" ref={this.linkRef}>
+        <a className="app__hide" href="/#" ref={this.linkRef}>
           download
         </a>
       </Fragment>

--- a/src/views/Catalog.js
+++ b/src/views/Catalog.js
@@ -18,9 +18,7 @@ function Catalog({ match }) {
       <div className="catalog__header-wrapper">
         <h1 className="catalog__header">Catalog</h1>
         <div className="catalog__header-buttons-wrapper app__hide-on-mobile">
-          {catalogFilter === "priorities" || catalogFilter === "all" ? (
-            <DownloadCatalogFilterTleButton catalogFilter={catalogFilter} />
-          ) : null}
+          <DownloadCatalogFilterTleButton catalogFilter={catalogFilter} />
 
           <NavLink className="app__nav-link" to="/submit">
             <span className="catalog__button catalog__get-data-button">


### PR DESCRIPTION
- Up until now the front end restricted the user to downloading TLEs classed by TruSat as `priorities` and `all`
- The button to download TLEs now renders for all filters chosen so that it can be tested against for all celestrak categories that are now available in the dev environment