### PR TITLE
Celestrak Categories feature

### DIFF
--- a/src/catalog/catalog-styles.scss
+++ b/src/catalog/catalog-styles.scss
@@ -187,6 +187,7 @@ CATALOG MORE DROPDOWN
 
 .catalog-more-dropdown__group-header:hover {
   cursor: pointer;
+  text-decoration: underline;
 }
 
 .catalog-more-dropdown__link {
@@ -197,6 +198,7 @@ CATALOG MORE DROPDOWN
 
 .catalog-more-dropdown__link:hover {
   cursor: pointer;
+  text-decoration: underline;
 }
 
 /* ----------

--- a/src/catalog/catalog-styles.scss
+++ b/src/catalog/catalog-styles.scss
@@ -182,8 +182,7 @@ CATALOG MORE DROPDOWN
 }
 
 .catalog-more-dropdown__group-header {
-  font-size: $medium-font-size;
-  font-style: bold;
+  font-weight: bold;
 }
 
 .catalog-more-dropdown__group-header:hover {

--- a/src/catalog/components/CatalogNavBar.js
+++ b/src/catalog/components/CatalogNavBar.js
@@ -27,6 +27,8 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
         <h1
           className="catalog-more-dropdown__group-header"
           onClick={() => {
+            setRange({ start: 0, end: 10 });
+            setDataStart(0);
             setShowMore(false);
             history.push(`/catalog/${group.groupHeader.path}`);
           }}
@@ -38,6 +40,8 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
           <p
             key={`${category.path}`}
             onClick={() => {
+              setRange({ start: 0, end: 10 });
+              setDataStart(0);
               setShowMore(false);
               history.push(`/catalog/${category.path}`);
             }}

--- a/src/catalog/components/CatalogTable.js
+++ b/src/catalog/components/CatalogTable.js
@@ -134,7 +134,7 @@ export default function CatalogTable({
         </table>
       ) : (
         <p className="app__error-message">
-          The TruSat catalog does not currently have any objects matching the
+          The catalog does not currently include any objects that match the
           filter chosen
         </p>
       )}

--- a/src/catalog/components/CatalogTable.js
+++ b/src/catalog/components/CatalogTable.js
@@ -24,75 +24,79 @@ export default function CatalogTable({
   }, [catalogFilter, dataStart, doFetch]);
 
   const renderCatalogRows = () => {
-    const { start, end } = range;
+    // Render rows if data is returned (some filters may not return any data)
+    if (data.length !== 0) {
+      // get current range as determined by the TablePaginator component
+      const { start, end } = range;
+      // get the data to be displayed using the range
+      const rangeData = data.slice(start, end);
 
-    const rangeData = data.slice(start, end);
-
-    return rangeData.map(obj => (
-      <tr
-        key={data.indexOf(obj)}
-        className="table__body-row catalog-table__body-row"
-      >
-        <td className="table__table-data table__table-data--big_rows">
-          <NavLink
-            className="app__nav-link"
-            to={`/object/${obj.object_norad_number}`}
-          >
-            <div className="catalog-table__object-data-wrapper">
-              {catalogFilter === "priorities" ? (
-                <p className="catalog-table__object-data-wrapper--priority-rank">
-                  {dataStart + data.indexOf(obj) + 1}
-                  &nbsp;
-                </p>
-              ) : null}
-              <ObjectBadge
-                noradNumber={obj.object_norad_number}
-                size={"small"}
-              />
-              &nbsp;
-              <div className="catalog-table__object-data-wrapper--object-name">
-                {obj.object_name}
+      return rangeData.map(obj => (
+        <tr
+          key={data.indexOf(obj)}
+          className="table__body-row catalog-table__body-row"
+        >
+          <td className="table__table-data table__table-data--big_rows">
+            <NavLink
+              className="app__nav-link"
+              to={`/object/${obj.object_norad_number}`}
+            >
+              <div className="catalog-table__object-data-wrapper">
+                {catalogFilter === "priorities" ? (
+                  <p className="catalog-table__object-data-wrapper--priority-rank">
+                    {dataStart + data.indexOf(obj) + 1}
+                    &nbsp;
+                  </p>
+                ) : null}
+                <ObjectBadge
+                  noradNumber={obj.object_norad_number}
+                  size={"small"}
+                />
+                &nbsp;
+                <div className="catalog-table__object-data-wrapper--object-name">
+                  {obj.object_name}
+                </div>
               </div>
-            </div>
-          </NavLink>
-        </td>
+            </NavLink>
+          </td>
 
-        <td className="table__table-data catalog-table__table-data--origin-wrapper">
-          <NavLink
-            className="app__nav-link"
-            to={`/object/${obj.object_norad_number}`}
-          >
-            {renderFlag(obj.object_origin)}
-          </NavLink>
-        </td>
+          <td className="table__table-data catalog-table__table-data--origin-wrapper">
+            <NavLink
+              className="app__nav-link"
+              to={`/object/${obj.object_norad_number}`}
+            >
+              {renderFlag(obj.object_origin)}
+            </NavLink>
+          </td>
 
-        <td className="table__table-data app__hide-on-mobile catalog-table__table-data--purpose-wrapper">
-          <NavLink
-            className="app__nav-link"
-            to={`/object/${obj.object_norad_number}`}
-          >
-            {obj.object_merged_description}
-          </NavLink>
-        </td>
-        <td className="table__table-data app__hide-on-mobile">
-          <NavLink
-            className="app__nav-link"
-            to={`/object/${obj.object_norad_number}`}
-          >
-            {/* {obj.object_observation_quality}% */}
-            TBD
-          </NavLink>
-        </td>
-        <td className="table__table-data catalog-table__table-data--username-wrapper">
-          <NavLink
-            className="app__nav-link"
-            to={`/profile/${obj.address_last_tracked}`}
-          >
-            {toolTip(obj.username_last_tracked, obj.address_last_tracked)}
-          </NavLink>
-        </td>
-      </tr>
-    ));
+          <td className="table__table-data app__hide-on-mobile catalog-table__table-data--purpose-wrapper">
+            <NavLink
+              className="app__nav-link"
+              to={`/object/${obj.object_norad_number}`}
+            >
+              {obj.object_merged_description}
+            </NavLink>
+          </td>
+          <td className="table__table-data app__hide-on-mobile">
+            <NavLink
+              className="app__nav-link"
+              to={`/object/${obj.object_norad_number}`}
+            >
+              {/* {obj.object_observation_quality}% */}
+              TBD
+            </NavLink>
+          </td>
+          <td className="table__table-data catalog-table__table-data--username-wrapper">
+            <NavLink
+              className="app__nav-link"
+              to={`/profile/${obj.address_last_tracked}`}
+            >
+              {toolTip(obj.username_last_tracked, obj.address_last_tracked)}
+            </NavLink>
+          </td>
+        </tr>
+      ));
+    }
   };
 
   return isLoading ? (
@@ -103,7 +107,9 @@ export default function CatalogTable({
         <p className="app__error-message">
           Something went wrong... {errorMessage}
         </p>
-      ) : (
+      ) : null}
+      {/* // Only render the table headers if data is returned for a given filter */}
+      {data.length !== 0 ? (
         <table className="table">
           <thead className="table__header">
             <tr className="table__header-row">
@@ -126,7 +132,13 @@ export default function CatalogTable({
           </thead>
           <tbody className="table__body">{renderCatalogRows()}</tbody>
         </table>
+      ) : (
+        <p className="app__error-message">
+          The TruSat catalog does not currently have any objects matching the
+          filter chosen
+        </p>
       )}
+
       {data.length > 10 ? (
         <TablePaginator
           tableDataLength={data.length}

--- a/src/catalog/components/FilterDescription.js
+++ b/src/catalog/components/FilterDescription.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 
 export default function FilterDescription({
   catalogFilter,

--- a/src/catalog/components/FilterDescription.js
+++ b/src/catalog/components/FilterDescription.js
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { Fragment } from "react";
 
-export default function FilterDescription({ catalogFilter }) {
+export default function FilterDescription({
+  catalogFilter,
+  celestrakCategories
+}) {
   const filterDescriptions = [
     {
       filter: "priorities",
@@ -29,7 +32,25 @@ export default function FilterDescription({ catalogFilter }) {
     description => description.filter === catalogFilter
   );
 
-  // if featured filter was chosen
+  console.log(celestrakCategories);
+
+  const getCelestrakCategoryName = () => {
+    if (celestrakCategories) {
+      // check group headers for a match first
+      // returns an array containing one object if a match is found
+      const groupHeaderMatch = celestrakCategories.filter(
+        group => group.groupHeader.path === catalogFilter
+      );
+      // return the "title" of the group header if the paths (url and API) match
+      if (groupHeaderMatch.length !== 0) {
+        return groupHeaderMatch[0].groupHeader.title;
+      } else {
+        return catalogFilter;
+      }
+    }
+  };
+
+  // if a NavBar "featured" filter was chosen
   return featuredDescription.length === 1 ? (
     // return detailed description of featured filter
     <p
@@ -39,9 +60,10 @@ export default function FilterDescription({ catalogFilter }) {
       {featuredDescription[0].copy}
     </p>
   ) : (
-    // otherwise return generic description of regular filter found in "more" dropdown
+    // otherwise return generic description of celestrak category filter found in "more" dropdown
     <p key={`${catalogFilter} copy`} className="catalog__filter-description">
-      {`All the objects classified as "${catalogFilter}" in the TruSat Catalog`}
+      All the objects classified as {getCelestrakCategoryName()} in the TruSat
+      Catalog
     </p>
   );
 }

--- a/src/catalog/components/FilterDescription.js
+++ b/src/catalog/components/FilterDescription.js
@@ -32,7 +32,7 @@ export default function FilterDescription({
     description => description.filter === catalogFilter
   );
 
-  console.log(celestrakCategories);
+  //console.log(celestrakCategories);
 
   const getCelestrakCategoryName = () => {
     if (celestrakCategories) {
@@ -41,11 +41,22 @@ export default function FilterDescription({
       const groupHeaderMatch = celestrakCategories.filter(
         group => group.groupHeader.path === catalogFilter
       );
-      // return the "title" of the group header if the paths (url and API) match
+      // return the "title" of the groupHeader if the paths (groupHeader and catalogFilter) match
       if (groupHeaderMatch.length !== 0) {
-        return groupHeaderMatch[0].groupHeader.title;
+        return `${groupHeaderMatch[0].groupHeader.title} (${catalogFilter})`;
       } else {
-        return catalogFilter;
+        const groupCategoryMatch = celestrakCategories.map(group =>
+          group.groupCategories.filter(
+            groupCat => groupCat.path === catalogFilter
+          )
+        );
+
+        if (groupCategoryMatch.length !== 0) {
+          // TO DO - fix the bug where an array is returned with empty arrays for each filter than doesnt match
+          console.log(groupCategoryMatch);
+
+          return `${groupCategoryMatch[0].title} (${catalogFilter})`;
+        }
       }
     }
   };

--- a/src/catalog/components/FilterDescription.js
+++ b/src/catalog/components/FilterDescription.js
@@ -52,10 +52,8 @@ export default function FilterDescription({
         );
 
         if (groupCategoryMatch.length !== 0) {
-          // TO DO - fix the bug where an array is returned with empty arrays for each filter than doesnt match
-          console.log(groupCategoryMatch);
-
-          return `${groupCategoryMatch[0].title} (${catalogFilter})`;
+          // "flat" reduce the array of arrays into a single array containing 1 object - the group category match
+          return `${groupCategoryMatch.flat(1)[0].title} (${catalogFilter})`;
         }
       }
     }


### PR DESCRIPTION
- Updates the styling of the category groups in the dropdown to be more uniform. The headers (group categories) are now bold.
- The filter description now render the "title" of the celestrak category that was chosen, along with the "path" in parenthesis 
- Underline is added to the hover effect on dropdown link to improve highlighting 
- Bug fixed where the `TablePaginator` range was not being reset to `0-10` when user clicked a new filter
- Conditional rendering is now added to the `CatalogTable` component. A generic message of `The catalog does not currently include any objects that match the filter chosen` is now rendered when an empty array is returned from a fetch call to the `/catalog/${catalogFilter}` endpoint