### PR TITLE
Fix DownloadTLE button bug

### DIFF
--- a/src/catalog/components/CatalogTable.js
+++ b/src/catalog/components/CatalogTable.js
@@ -15,13 +15,14 @@ export default function CatalogTable({
   range,
   setRange,
   dataStart,
-  setDataStart
+  setDataStart,
+  setShowDownloadButton
 }) {
   const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 
   useEffect(() => {
     doFetch(`/catalog/${catalogFilter}/${dataStart}`);
-  }, [catalogFilter, dataStart, doFetch]);
+  }, [catalogFilter, dataStart, doFetch, setShowDownloadButton]);
 
   const renderCatalogRows = () => {
     // Render rows if data is returned (some filters may not return any data)
@@ -30,6 +31,8 @@ export default function CatalogTable({
       const { start, end } = range;
       // get the data to be displayed using the range
       const rangeData = data.slice(start, end);
+      // show the download button after it is confirmed that data exists to be rendered in the table
+      setShowDownloadButton(true);
 
       return rangeData.map(obj => (
         <tr
@@ -100,7 +103,11 @@ export default function CatalogTable({
   };
 
   return isLoading ? (
-    <Spinner />
+    <Fragment>
+      {/* hide download TLEs button until it is confirmed that data exists to be rendered in the table */}
+      {setShowDownloadButton(false)}
+      <Spinner />
+    </Fragment>
   ) : (
     <Fragment>
       {errorMessage ? (

--- a/src/catalog/components/DownloadCatalogFilterTleButton.js
+++ b/src/catalog/components/DownloadCatalogFilterTleButton.js
@@ -43,7 +43,9 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
   };
 
   render() {
-    return (
+    // Only show the download button when data is returned from the /catalog endpoint
+    console.log(this.props);
+    return this.props.showDownloadButton ? (
       <Fragment>
         <span
           className="catalog__button catalog__get-data-button"
@@ -70,6 +72,6 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
           download
         </a>
       </Fragment>
-    );
+    ) : null;
   }
 }

--- a/src/views/Catalog.js
+++ b/src/views/Catalog.js
@@ -12,13 +12,17 @@ function Catalog({ match }) {
   const [dataStart, setDataStart] = useState(0);
   // Used by TablePaginator component rendered under the CatalogTable
   const [range, setRange] = useState({ start: 0, end: 10 });
+  const [showDownloadButton, setShowDownloadButton] = useState(false);
 
   return (
     <div className="catalog__wrapper">
       <div className="catalog__header-wrapper">
         <h1 className="catalog__header">Catalog</h1>
         <div className="catalog__header-buttons-wrapper app__hide-on-mobile">
-          <DownloadCatalogFilterTleButton catalogFilter={catalogFilter} />
+          <DownloadCatalogFilterTleButton
+            catalogFilter={catalogFilter}
+            showDownloadButton={showDownloadButton}
+          />
 
           <NavLink className="app__nav-link" to="/submit">
             <span className="catalog__button catalog__get-data-button">
@@ -54,6 +58,7 @@ function Catalog({ match }) {
         setRange={setRange}
         dataStart={dataStart}
         setDataStart={setDataStart}
+        setShowDownloadButton={setShowDownloadButton}
       />
       {/* Shown on mobile */}
       <section className="app__show-on-mobile">


### PR DESCRIPTION
- Some Celestrak Categories do not return any data to the front end (to be rendered in the catalog table).
- When this happens, the `DownloadCatalogFilterTLEButton` was still rendered, even though there is no TLE data to be downloaded. 
- With this change the button gets hidden from the UI when a call to the `/catalog/${catalogFilter}` endpoint is made, and appears again only when data is returned (to be rendered in the table) 