### PR TITLE
Feature/filter description

### DIFF
--- a/src/catalog/components/CatalogNavBar.js
+++ b/src/catalog/components/CatalogNavBar.js
@@ -9,7 +9,15 @@ import IconTrash from "../../assets/icon-trash.svg";
 import Spinner from "../../app/components/Spinner";
 import FilterDescription from "./FilterDescription";
 
-function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
+function CatalogNavBar({
+  catalogFilter,
+  dataStart,
+  objectCount,
+  setRange,
+  setDataStart,
+  history,
+  isLoadingCatalog,
+}) {
   const [showMore, setShowMore] = useState(false);
   const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 
@@ -19,7 +27,7 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
 
   // renders the celestrak categories received from API to the "more" dropdown
   const renderCelestrakCategories = () => {
-    return data.data.map(group => (
+    return data.data.map((group) => (
       <div
         key={`${group.groupHeader.path}`}
         className="catalog-more-dropdown__group"
@@ -36,7 +44,7 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
           {group.groupHeader.title}
         </h1>
 
-        {group.groupCategories.map(category => (
+        {group.groupCategories.map((category) => (
           <p
             key={`${category.path}`}
             onClick={() => {
@@ -69,7 +77,7 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
             ReactGA.event({
               category: "Catalog",
               action: "User chose a filter",
-              label: "priorities"
+              label: "priorities",
             });
             history.push("/catalog/priorities");
           }}
@@ -90,7 +98,7 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
             ReactGA.event({
               category: "Catalog",
               action: "User chose a filter",
-              label: "latest"
+              label: "latest",
             });
             history.push("/catalog/latest");
           }}
@@ -111,7 +119,7 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
             ReactGA.event({
               category: "Catalog",
               action: "User chose a filter",
-              label: "undisclosed"
+              label: "undisclosed",
             });
             history.push("/catalog/undisclosed");
           }}
@@ -132,7 +140,7 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
             ReactGA.event({
               category: "Catalog",
               action: "User chose a filter",
-              label: "debris"
+              label: "debris",
             });
             history.push("/catalog/debris");
           }}
@@ -171,10 +179,14 @@ function CatalogNavBar({ catalogFilter, setRange, setDataStart, history }) {
         </section>
       ) : null}
 
-      <FilterDescription
-        catalogFilter={catalogFilter}
-        celestrakCategories={data.data}
-      />
+      {isLoadingCatalog ? null : (
+        <FilterDescription
+          catalogFilter={catalogFilter}
+          celestrakCategories={data.data}
+          objectCount={objectCount}
+          dataStart={dataStart}
+        />
+      )}
     </React.Fragment>
   );
 }

--- a/src/catalog/components/CatalogTable.js
+++ b/src/catalog/components/CatalogTable.js
@@ -1,42 +1,28 @@
-import React, { useEffect, Fragment } from "react";
+import React, { Fragment } from "react";
 import { NavLink } from "react-router-dom";
-import Spinner from "../../app/components/Spinner";
 import ObjectBadge from "../../app/components/ObjectBadge";
-import {
-  useTrusatGetApi,
-  renderFlag,
-  toolTip,
-  toolTipCopy
-} from "../../app/app-helpers";
+import { renderFlag, toolTip, toolTipCopy } from "../../app/app-helpers";
 import TablePaginator from "../../app/components/TablePaginator";
 
 export default function CatalogTable({
   catalogFilter,
+  catalogData,
   range,
   setRange,
   dataStart,
   setDataStart,
-  setShowDownloadButton
 }) {
-  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
-
-  useEffect(() => {
-    doFetch(`/catalog/${catalogFilter}/${dataStart}`);
-  }, [catalogFilter, dataStart, doFetch, setShowDownloadButton]);
-
   const renderCatalogRows = () => {
     // Render rows if data is returned (some filters may not return any data)
-    if (data.length !== 0) {
+    if (catalogData.length !== 0) {
       // get current range as determined by the TablePaginator component
       const { start, end } = range;
       // get the data to be displayed using the range
-      const rangeData = data.slice(start, end);
-      // show the download button after it is confirmed that data exists to be rendered in the table
-      setShowDownloadButton(true);
+      const rangeData = catalogData.slice(start, end);
 
-      return rangeData.map(obj => (
+      return rangeData.map((obj) => (
         <tr
-          key={data.indexOf(obj)}
+          key={catalogData.indexOf(obj)}
           className="table__body-row catalog-table__body-row"
         >
           <td className="table__table-data table__table-data--big_rows">
@@ -47,7 +33,7 @@ export default function CatalogTable({
               <div className="catalog-table__object-data-wrapper">
                 {catalogFilter === "priorities" ? (
                   <p className="catalog-table__object-data-wrapper--priority-rank">
-                    {dataStart + data.indexOf(obj) + 1}
+                    {dataStart + catalogData.indexOf(obj) + 1}
                     &nbsp;
                   </p>
                 ) : null}
@@ -102,21 +88,9 @@ export default function CatalogTable({
     }
   };
 
-  return isLoading ? (
+  return (
     <Fragment>
-      {/* hide download TLEs button until it is confirmed that data exists to be rendered in the table */}
-      {setShowDownloadButton(false)}
-      <Spinner />
-    </Fragment>
-  ) : (
-    <Fragment>
-      {errorMessage ? (
-        <p className="app__error-message">
-          Something went wrong... {errorMessage}
-        </p>
-      ) : null}
-      {/* // Only render the table headers if data is returned for a given filter */}
-      {data.length !== 0 ? (
+      {catalogData.length !== 0 ? (
         <table className="table">
           <thead className="table__header">
             <tr className="table__header-row">
@@ -146,9 +120,9 @@ export default function CatalogTable({
         </p>
       )}
 
-      {data.length > 10 ? (
+      {catalogData.length > 10 ? (
         <TablePaginator
-          tableDataLength={data.length}
+          tableDataLength={catalogData.length}
           range={range}
           setRange={setRange}
           dataStart={dataStart}

--- a/src/catalog/components/DownloadCatalogFilterTleButton.js
+++ b/src/catalog/components/DownloadCatalogFilterTleButton.js
@@ -6,7 +6,7 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
   state = {
     isLoading: false,
     errorMessage: "",
-    textFile: null
+    textFile: null,
   };
 
   linkRef = React.createRef();
@@ -29,7 +29,7 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
 
       const href = window.URL.createObjectURL(
         new Blob([this.state.textFile], {
-          type: "text/csv"
+          type: "text/csv",
         })
       );
       this.linkRef.current.download = `trusat_${this.props.catalogFilter}.txt`;
@@ -43,9 +43,7 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
   };
 
   render() {
-    // Only show the download button when data is returned from the /catalog endpoint
-    console.log(this.props);
-    return this.props.showDownloadButton ? (
+    return (
       <Fragment>
         <span
           className="catalog__button catalog__get-data-button"
@@ -53,15 +51,17 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
             ReactGA.event({
               category: "TLE usage",
               action: `Clicked download predictions button`,
-              label: `Download TLEs from ${this.props.catalogFilter}`
+              label: `Download TLEs from ${this.props.catalogFilter}`,
             });
             this.fetchData();
           }}
         >
           {this.state.isLoading
             ? "...Loading"
-            : `Download ${this.props.catalogFilter.charAt(0).toUpperCase() +
-                this.props.catalogFilter.slice(1)} TLEs`}
+            : `Download ${
+                this.props.catalogFilter.charAt(0).toUpperCase() +
+                this.props.catalogFilter.slice(1)
+              } TLEs`}
         </span>
 
         {this.state.errorMessage ? (
@@ -72,6 +72,6 @@ export default class DownloadCatalogFilterTleButton extends React.Component {
           download
         </a>
       </Fragment>
-    ) : null;
+    );
   }
 }

--- a/src/catalog/components/FilterDescription.js
+++ b/src/catalog/components/FilterDescription.js
@@ -2,52 +2,52 @@ import React from "react";
 
 export default function FilterDescription({
   catalogFilter,
-  celestrakCategories
+  celestrakCategories,
+  objectCount,
+  dataStart,
 }) {
   const filterDescriptions = [
     {
       filter: "priorities",
       copy:
-        "The satellites most in need of monitoring by the space sustainability community. This list is auto-generated. Open a satellite for details on when and where to see it."
+        "The satellites most in need of monitoring by the space sustainability community. This list is auto-generated. Open a satellite for details on when and where to see it.",
     },
     {
       filter: "undisclosed",
-      copy: "These satellites do not appear in public space object catalogs."
+      copy: "These satellites do not appear in public space object catalogs.",
     },
     {
       filter: "debris",
       copy:
-        "Old satellites, spent rocket stages, and the fragments from their disintegration and collisions."
+        "Old satellites, spent rocket stages, and the fragments from their disintegration and collisions.",
     },
     {
       filter: "latest",
       copy:
-        "The most recently launched objects in the catalog need fresh observations."
+        "The most recently launched objects in the catalog need fresh observations.",
     },
-    { filter: "all", copy: "All objects of the TruSat catalog." }
+    { filter: "all", copy: "All objects of the TruSat catalog." },
   ];
 
   // Will return an array with 1 object if a featured filter was chosen
   const featuredDescription = filterDescriptions.filter(
-    description => description.filter === catalogFilter
+    (description) => description.filter === catalogFilter
   );
-
-  //console.log(celestrakCategories);
 
   const getCelestrakCategoryName = () => {
     if (celestrakCategories) {
       // check group headers for a match first
       // returns an array containing one object if a match is found
       const groupHeaderMatch = celestrakCategories.filter(
-        group => group.groupHeader.path === catalogFilter
+        (group) => group.groupHeader.path === catalogFilter
       );
       // return the "title" of the groupHeader if the paths (groupHeader and catalogFilter) match
       if (groupHeaderMatch.length !== 0) {
         return `${groupHeaderMatch[0].groupHeader.title} (${catalogFilter})`;
       } else {
-        const groupCategoryMatch = celestrakCategories.map(group =>
+        const groupCategoryMatch = celestrakCategories.map((group) =>
           group.groupCategories.filter(
-            groupCat => groupCat.path === catalogFilter
+            (groupCat) => groupCat.path === catalogFilter
           )
         );
 
@@ -71,8 +71,19 @@ export default function FilterDescription({
   ) : (
     // otherwise return generic description of celestrak category filter found in "more" dropdown
     <p key={`${catalogFilter} copy`} className="catalog__filter-description">
-      All the objects classified as {getCelestrakCategoryName()} in the TruSat
-      Catalog
+      {objectCount === 0
+        ? `All objects classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
+        : null}
+
+      {objectCount === 200
+        ? `All objects from ${dataStart + 1} - ${
+            dataStart + objectCount
+          } classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
+        : null}
+
+      {objectCount !== 0 && objectCount < 200
+        ? `All ${objectCount} objects classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
+        : null}
     </p>
   );
 }


### PR DESCRIPTION
closes #289 

- This required a refactor of the `Catalog` "view" component, as well as the `CatalogTable`.
- The fetch call to the `/catalog/${catalogFilter}` endpoint is now handled within the `Catalog` component. This means that the data (and in particular the length of the data - i.e. no. of objects) can now be easily passed down to the `FilterDescription` component
- The `FilterDescription` component now has three different values that can be rendered - and this is determined by how many objects have been retrieved from the `/catalog` endpoint.