### PR TITLE
Utilize new values provided by /catalog endpoint

### DIFF
--- a/src/catalog/components/CatalogTable.js
+++ b/src/catalog/components/CatalogTable.js
@@ -6,7 +6,7 @@ import TablePaginator from "../../app/components/TablePaginator";
 
 export default function CatalogTable({
   catalogFilter,
-  catalogData,
+  catalogObjects,
   range,
   setRange,
   dataStart,
@@ -14,15 +14,15 @@ export default function CatalogTable({
 }) {
   const renderCatalogRows = () => {
     // Render rows if data is returned (some filters may not return any data)
-    if (catalogData.length !== 0) {
+    if (catalogObjects.length !== 0) {
       // get current range as determined by the TablePaginator component
       const { start, end } = range;
       // get the data to be displayed using the range
-      const rangeData = catalogData.slice(start, end);
+      const rangeData = catalogObjects.slice(start, end);
 
       return rangeData.map((obj) => (
         <tr
-          key={catalogData.indexOf(obj)}
+          key={catalogObjects.indexOf(obj)}
           className="table__body-row catalog-table__body-row"
         >
           <td className="table__table-data table__table-data--big_rows">
@@ -33,7 +33,7 @@ export default function CatalogTable({
               <div className="catalog-table__object-data-wrapper">
                 {catalogFilter === "priorities" ? (
                   <p className="catalog-table__object-data-wrapper--priority-rank">
-                    {dataStart + catalogData.indexOf(obj) + 1}
+                    {dataStart + catalogObjects.indexOf(obj) + 1}
                     &nbsp;
                   </p>
                 ) : null}
@@ -90,7 +90,7 @@ export default function CatalogTable({
 
   return (
     <Fragment>
-      {catalogData.length !== 0 ? (
+      {catalogObjects.length !== 0 ? (
         <table className="table">
           <thead className="table__header">
             <tr className="table__header-row">
@@ -120,9 +120,9 @@ export default function CatalogTable({
         </p>
       )}
 
-      {catalogData.length > 10 ? (
+      {catalogObjects.length > 10 ? (
         <TablePaginator
-          tableDataLength={catalogData.length}
+          tableDataLength={catalogObjects.length}
           range={range}
           setRange={setRange}
           dataStart={dataStart}

--- a/src/catalog/components/FilterDescription.js
+++ b/src/catalog/components/FilterDescription.js
@@ -81,7 +81,7 @@ export default function FilterDescription({
           } classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
         : null} */}
 
-      {objectCount !== 0 && objectCount < 200
+      {objectCount !== 0
         ? `All ${objectCount} objects classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
         : `All objects classified as ${getCelestrakCategoryName()} in the TruSat Catalog`}
     </p>

--- a/src/views/Catalog.js
+++ b/src/views/Catalog.js
@@ -14,20 +14,23 @@ function Catalog({ match }) {
   const [dataStart, setDataStart] = useState(0);
   // Used by TablePaginator component rendered under the CatalogTable
   const [range, setRange] = useState({ start: 0, end: 10 });
-  const [showDownloadButton, setShowDownloadButton] = useState(false);
 
   const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
+  const [objects, setObjects] = useState([]);
+  const [objectCount, setObjectCount] = useState(0);
+  const [tleCount, setTleCount] = useState(0);
 
   useEffect(() => {
-    setShowDownloadButton(false);
-
     doFetch(`/catalog/${catalogFilter}/${dataStart}`);
 
     if (data.length !== 0) {
-      // only show option to download TLEs if data for CatalogTable is available
-      setShowDownloadButton(true);
+      const { objects, object_count, tle_count } = data;
+
+      setObjects(objects);
+      setObjectCount(object_count);
+      setTleCount(tle_count);
     }
-  }, [catalogFilter, dataStart, doFetch, setShowDownloadButton, data]);
+  }, [catalogFilter, dataStart, doFetch, data]);
 
   return (
     <div className="catalog__wrapper">
@@ -35,7 +38,7 @@ function Catalog({ match }) {
         <h1 className="catalog__header">Catalog</h1>
         <div className="catalog__header-buttons-wrapper app__hide-on-mobile">
           {/* show the download button after it is confirmed that data exists to be rendered in the table */}
-          {showDownloadButton ? (
+          {tleCount !== 0 ? (
             <DownloadCatalogFilterTleButton catalogFilter={catalogFilter} />
           ) : null}
 
@@ -61,7 +64,7 @@ function Catalog({ match }) {
             setRange={setRange}
             dataStart={dataStart}
             setDataStart={setDataStart}
-            objectCount={data.length}
+            objectCount={objectCount}
           />
         </div>
         {/* Shown on desktop */}
@@ -81,14 +84,13 @@ function Catalog({ match }) {
           ) : (
             <CatalogTable
               catalogFilter={catalogFilter}
-              catalogData={data}
+              catalogObjects={objects}
               isLoading={isLoading}
               errorMessage={errorMessage}
               range={range}
               setRange={setRange}
               dataStart={dataStart}
               setDataStart={setDataStart}
-              setShowDownloadButton={setShowDownloadButton}
             />
           )}
         </Fragment>


### PR DESCRIPTION
Catalog endpoint now provides three values:
1. `objects` (the array of objects - one for each satellite object
2. `object_count`(the total number of objects that TruSat holds for a given `catalogFilter`)
3. `tle_count` (the total number of TLEs that TruSat holds for a given `catalogFilter`)

This change refactors code to utilize the addition of values for 2 and 3.