### PR TITLE
Feature/celestrak categories

### DIFF
--- a/src/catalog/components/CatalogNavBar.js
+++ b/src/catalog/components/CatalogNavBar.js
@@ -11,12 +11,11 @@ import FilterDescription from "./FilterDescription";
 
 function CatalogNavBar({
   catalogFilter,
-  dataStart,
   objectCount,
   setRange,
   setDataStart,
   history,
-  isLoadingCatalog,
+  setTleCount,
 }) {
   const [showMore, setShowMore] = useState(false);
   const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
@@ -35,6 +34,7 @@ function CatalogNavBar({
         <h1
           className="catalog-more-dropdown__group-header"
           onClick={() => {
+            setTleCount(0); // hides the download TLEs button until it is confirmed that TLEs are available
             setRange({ start: 0, end: 10 });
             setDataStart(0);
             setShowMore(false);
@@ -48,6 +48,7 @@ function CatalogNavBar({
           <p
             key={`${category.path}`}
             onClick={() => {
+              setTleCount(0);
               setRange({ start: 0, end: 10 });
               setDataStart(0);
               setShowMore(false);
@@ -72,6 +73,7 @@ function CatalogNavBar({
               : "catalog-nav-bar__link--lowlight"
           }
           onClick={() => {
+            setTleCount(0);
             setRange({ start: 0, end: 10 });
             setDataStart(0);
             ReactGA.event({
@@ -93,6 +95,7 @@ function CatalogNavBar({
               : "catalog-nav-bar__link--lowlight"
           }
           onClick={() => {
+            setTleCount(0);
             setRange({ start: 0, end: 10 });
             setDataStart(0);
             ReactGA.event({
@@ -114,6 +117,7 @@ function CatalogNavBar({
               : "catalog-nav-bar__link--lowlight"
           }
           onClick={() => {
+            setTleCount(0);
             setRange({ start: 0, end: 10 });
             setDataStart(0);
             ReactGA.event({
@@ -135,6 +139,7 @@ function CatalogNavBar({
               : "catalog-nav-bar__link--lowlight"
           }
           onClick={() => {
+            setTleCount(0);
             setRange({ start: 0, end: 10 });
             setDataStart(0);
             ReactGA.event({
@@ -179,14 +184,11 @@ function CatalogNavBar({
         </section>
       ) : null}
 
-      {isLoadingCatalog ? null : (
-        <FilterDescription
-          catalogFilter={catalogFilter}
-          celestrakCategories={data.data}
-          objectCount={objectCount}
-          dataStart={dataStart}
-        />
-      )}
+      <FilterDescription
+        catalogFilter={catalogFilter}
+        celestrakCategories={data.data}
+        objectCount={objectCount}
+      />
     </React.Fragment>
   );
 }

--- a/src/catalog/components/CatalogNavDropdown.js
+++ b/src/catalog/components/CatalogNavDropdown.js
@@ -9,7 +9,7 @@ function NavDropdown({ catalogFilter, history, setRange, setDataStart }) {
     { value: "priorities", label: "PRIORITIES" },
     { value: "latest", label: "LAUNCHES" },
     { value: "undisclosed", label: "UNDISCLOSED" },
-    { value: "debris", label: "DEBRIS" }
+    { value: "debris", label: "DEBRIS" },
   ]);
   const [selectedOption, setSelectedOption] = useState("");
 
@@ -23,37 +23,37 @@ function NavDropdown({ catalogFilter, history, setRange, setDataStart }) {
       const celestrakCategories = [];
       // Adds all of the sub categories under Featured group header to the dropdown
       data.data
-        .filter(cat => cat.groupHeader.title === "Featured")
-        .map(cat =>
-          cat.groupCategories.map(featCat =>
+        .filter((cat) => cat.groupHeader.title === "Featured")
+        .map((cat) =>
+          cat.groupCategories.map((featCat) =>
             celestrakCategories.push({
               value: featCat.path,
-              label: featCat.title.toUpperCase()
+              label: featCat.title.toUpperCase(),
             })
           )
         );
       // Adds all of the remaining groupHeaders to the dropdown
       data.data
-        .filter(cat => cat.groupHeader.title !== "Featured")
-        .map(cat =>
+        .filter((cat) => cat.groupHeader.title !== "Featured")
+        .map((cat) =>
           celestrakCategories.push({
             value: cat.groupHeader.path,
-            label: cat.groupHeader.title.toUpperCase()
+            label: cat.groupHeader.title.toUpperCase(),
           })
         );
       // Merge the hardcoded options with those pulled from the api
-      setOptions(options => options.concat(celestrakCategories));
+      setOptions((options) => options.concat(celestrakCategories));
     }
   }, [data, doFetch]);
 
   // Handles case when user choses an option
   useEffect(() => {
     options
-      .filter(option => option.value === catalogFilter)
-      .map(option => setSelectedOption(option));
+      .filter((option) => option.value === catalogFilter)
+      .map((option) => setSelectedOption(option));
   }, [options, catalogFilter, setSelectedOption]);
 
-  const handleChange = newSelectedOption => {
+  const handleChange = (newSelectedOption) => {
     setRange({ start: 0, end: 10 });
     setDataStart(0);
 
@@ -67,17 +67,17 @@ function NavDropdown({ catalogFilter, history, setRange, setDataStart }) {
       border: "1px solid white",
       fontSize: "20px",
       fontWeight: "bold",
-      padding: "0.25em"
+      padding: "0.25em",
     }),
 
     menu: (provided, state) => ({
       ...provided,
       backgroundColor: "transparent",
-      marginTop: "0"
+      marginTop: "0",
     }),
 
     singleValue: (provided, state) => ({
-      color: "white"
+      color: "white",
     }),
 
     option: (provided, state) => ({
@@ -85,8 +85,8 @@ function NavDropdown({ catalogFilter, history, setRange, setDataStart }) {
       background: "#043053",
       borderBottom: "1px solid #4f4f4f",
       color: state.isSelected ? "#FC7756" : "white",
-      padding: "1em"
-    })
+      padding: "1em",
+    }),
   };
 
   return (

--- a/src/catalog/components/FilterDescription.js
+++ b/src/catalog/components/FilterDescription.js
@@ -4,7 +4,6 @@ export default function FilterDescription({
   catalogFilter,
   celestrakCategories,
   objectCount,
-  dataStart,
 }) {
   const filterDescriptions = [
     {
@@ -71,16 +70,6 @@ export default function FilterDescription({
   ) : (
     // otherwise return generic description of celestrak category filter found in "more" dropdown
     <p key={`${catalogFilter} copy`} className="catalog__filter-description">
-      {/* {objectCount === 0
-        ? `All objects classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
-        : null}
-
-      {objectCount === 200
-        ? `All objects from ${dataStart + 1} - ${
-            dataStart + objectCount
-          } classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
-        : null} */}
-
       {objectCount !== 0
         ? `All ${objectCount} objects classified as ${getCelestrakCategoryName()} in the TruSat Catalog`
         : `All objects classified as ${getCelestrakCategoryName()} in the TruSat Catalog`}

--- a/src/views/Catalog.js
+++ b/src/views/Catalog.js
@@ -20,6 +20,8 @@ function Catalog({ match }) {
   const [objectCount, setObjectCount] = useState(0);
   const [tleCount, setTleCount] = useState(0);
 
+  console.log(`tleCount = `, tleCount);
+
   useEffect(() => {
     doFetch(`/catalog/${catalogFilter}/${dataStart}`);
 
@@ -37,10 +39,10 @@ function Catalog({ match }) {
       <div className="catalog__header-wrapper">
         <h1 className="catalog__header">Catalog</h1>
         <div className="catalog__header-buttons-wrapper app__hide-on-mobile">
-          {/* show the download button after it is confirmed that data exists to be rendered in the table */}
-          {tleCount !== 0 ? (
+          {/* show the download button after it is confirmed tles are available for download */}
+          {tleCount === 0 ? null : (
             <DownloadCatalogFilterTleButton catalogFilter={catalogFilter} />
-          ) : null}
+          )}
 
           <NavLink className="app__nav-link" to="/submit">
             <span className="catalog__button catalog__get-data-button">
@@ -65,6 +67,7 @@ function Catalog({ match }) {
             dataStart={dataStart}
             setDataStart={setDataStart}
             objectCount={objectCount}
+            setTleCount={setTleCount}
           />
         </div>
         {/* Shown on desktop */}


### PR DESCRIPTION
- Removes unused props and code
- Passes `setTleCount()` to `CatalogNavBar` component so that it can be utilized to reset the tle count variable when a new catalog filter option is chosen. 
- This will hide the `DownloadCatalogFilterTleButton` from the UI, and it will only reappear when the data returned from the `/catalog/${catalogFilter}` endpoint confirms that there is TLEs available to download for that given filter