### PR TITLE
Fix bug with dropdown render

### DIFF
--- a/src/catalog/components/CatalogNavDropdown.js
+++ b/src/catalog/components/CatalogNavDropdown.js
@@ -18,8 +18,10 @@ function NavDropdown({ catalogFilter, history, setRange, setDataStart }) {
   useEffect(() => {
     doFetch("/catalog/list");
 
+    console.log(`data = `, data);
+
     // only run when data has come down from the api call
-    if (data == true) {
+    if (Object.keys(data).length !== 0) {
       const celestrakCategories = [];
       // Adds all of the sub categories under Featured group header to the dropdown
       data.data


### PR DESCRIPTION
- The catalog dropdown on mobile renders was not rendering the celestrak categories due a bug with the `if` conditional in the `useEffect` call. 
- The data is an `Object`, so the fix was as follows:
```
if (Object.keys(data).length !== 0) {
     // do fetch
}
```