### PR TITLE
Fix bug with hover state on "more" Catalog NavLink

### DIFF
--- a/src/catalog/components/CatalogNavBar.js
+++ b/src/catalog/components/CatalogNavBar.js
@@ -163,7 +163,7 @@ function CatalogNavBar({
               ? "catalog-more-dropdown__more-text"
               : "catalog-nav-bar__link--lowlight"
           }
-          onClick={() => setShowMore(true)}
+          onClick={() => setShowMore(!showMore)}
         >
           <span className="catalog-filter-label">MORE</span>
         </div>

--- a/src/catalog/components/CatalogNavDropdown.js
+++ b/src/catalog/components/CatalogNavDropdown.js
@@ -17,9 +17,6 @@ function NavDropdown({ catalogFilter, history, setRange, setDataStart }) {
 
   useEffect(() => {
     doFetch("/catalog/list");
-
-    console.log(`data = `, data);
-
     // only run when data has come down from the api call
     if (Object.keys(data).length !== 0) {
       const celestrakCategories = [];


### PR DESCRIPTION
- This change coverts the "hover" state functionality of the "more" link to a click event instead. 
- The hover state was giving some issues on Brave and IE explorers on windows devices. 
- The dropdown now opens and closes when the "more" link is clicked
- The dropdown also closes when a catalog filter is clicked.